### PR TITLE
Events v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@ PHP PagerDuty Events API
 PHP implementation of the [PagerDuty Events API V2](https://v2.developer.pagerduty.com/docs/events-api-v2)
 
 
-UPGRADE NOTICE:
+UPGRADE NOTICE
 ---
-The [Events API V2]((https://v2.developer.pagerduty.com/docs/events-api-v2)) is **not backwards compatible** with the [Events API V1](https://v2.developer.pagerduty.com/docs/events-api). Hence, this API has changed. If you are upgrading from a [2.* release](https://github.com/adilbaig/pagerduty/releases), make sure you pay attention to the contructor of the `TriggerEvent`
+The [Events API V2](https://v2.developer.pagerduty.com/docs/events-api-v2) is **not backwards compatible** with the [Events API V1](https://v2.developer.pagerduty.com/docs/events-api). Hence, this API has changed. If you are upgrading from a [2.* release](https://github.com/adilbaig/pagerduty/releases), make sure you pay attention to the contructor of the `TriggerEvent`
 
 [![Latest Stable Version](https://poser.pugx.org/adilbaig/pagerduty/v/stable.svg)](https://packagist.org/packages/adilbaig/pagerduty) [![Total Downloads](https://poser.pugx.org/adilbaig/pagerduty/downloads.svg)](https://packagist.org/packages/adilbaig/pagerduty) 
 
@@ -105,19 +105,20 @@ var_dump($response['dedup_key']);
 ````
 
 Acknowledge an event
+----
 
 ````php
 (new AcknowledgeEvent($routingKey, "dedup key"))->send();
 ````
 
 Resolve an event
-
+----
 ````php
 (new ResolveEvent($routingKey, "dedup key"))->send();
 ````
 
 Questions
-----
+---
 
 **Q.** How do i get the service key from PagerDuty?
 
@@ -126,7 +127,7 @@ Questions
 Read more here : https://v2.developer.pagerduty.com/v2/docs/events-api#getting-started
 
 Requirements
-----
+---
 This library needs the [curl pecl extension](https://php.net/curl).
 
 In Ubuntu 16.04, install it like so :

--- a/README.md
+++ b/README.md
@@ -117,6 +117,18 @@ Resolve an event
 (new ResolveEvent($routingKey, "dedup key"))->send();
 ````
 
+UnitTests
+---
+
+````bash
+> ./vendor/bin/phpunit test/
+.....                                                               5 / 5 (100%)
+
+Time: 37 ms, Memory: 4.00MB
+
+OK (5 tests, 6 assertions)
+````
+
 Questions
 ---
 

--- a/src/PagerDuty/AcknowledgeEvent.php
+++ b/src/PagerDuty/AcknowledgeEvent.php
@@ -10,10 +10,10 @@ namespace PagerDuty;
 class AcknowledgeEvent extends Event
 {
 
-    public function __construct($serviceKey, $incidentKey)
+    public function __construct($routingKey, $dedupKey)
     {
-        parent::__construct($serviceKey, 'acknowledge');
+        parent::__construct($routingKey, 'acknowledge');
 
-        $this->setIncidentKey($incidentKey);
+        $this->setDeDupKey($dedupKey);
     }
 }

--- a/src/PagerDuty/ResolveEvent.php
+++ b/src/PagerDuty/ResolveEvent.php
@@ -10,10 +10,10 @@ namespace PagerDuty;
 class ResolveEvent extends Event
 {
 
-    public function __construct($serviceKey, $incidentKey)
+    public function __construct($routingKey, $dedupKey)
     {
-        parent::__construct($serviceKey, 'resolve');
+        parent::__construct($routingKey, 'resolve');
 
-        $this->setIncidentKey($incidentKey);
+        $this->setDeDupKey($dedupKey);
     }
 }


### PR DESCRIPTION
Per the `[PD FAQ](https://v2.developer.pagerduty.com/docs/v1-rest-api-decommissioning-faq)`

> On October 19, 2018, at 22:00 PDT (UTC+7), the v1 REST API will be decommissioned and no longer operational.

This branch shifts the API to V2. It is slightly backwards incompatible, as V2 has introduced more mandatory parameters. Switching to this should simply be a matter of updating the `TriggerEvent` constructor